### PR TITLE
Fetch and display missions

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,11 +1,11 @@
 import { HashRouter, Routes, Route } from 'react-router-dom';
 
 import NavBar from './components/NavBar';
-// import Rockets from './components/Rockets';
+import Rockets from './components/Rockets';
 // import Missions from './components/Missions';
 import MyProfile from './components/MyProfile';
 import MissionsList from './routes/Missions';
-import RocketsList from './routes/Rockets';
+// import RocketsList from './routes/Rockets';
 
 function App() {
   return (
@@ -14,7 +14,7 @@ function App() {
       <Routes>
         <Route
           path="/"
-          element={<RocketsList />}
+          element={<Rockets />}
           basename="/https://mrcbq.github.io/space-travelers-capstone/"
         />
         <Route path="/missions" element={<MissionsList />} />

--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -1,0 +1,19 @@
+import PropTypes from 'prop-types';
+
+export default function Mission(props) {
+  const { name, description, isMember } = props;
+  return (
+    <tr>
+      <td>{name}</td>
+      <td>{description}</td>
+      <td>{isMember ? <div>Active Member</div> : <div>NOT A MEMBER</div>}</td>
+      <td>Join Mission</td>
+    </tr>
+  );
+}
+
+Mission.propTypes = {
+  name: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+  isMember: PropTypes.bool.isRequired,
+};

--- a/src/components/Missions.css
+++ b/src/components/Missions.css
@@ -1,0 +1,24 @@
+table {
+  margin: 1rem 2rem;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+th,
+td {
+  border: 1px solid #dee2e6;
+}
+
+tbody tr:nth-child(odd) {
+  background-color: #f2f2f2;
+}
+
+td {
+  padding: 0.5rem;
+  font-weight: 400;
+}
+
+td:first-child {
+  font-weight: bold;
+  padding: 1rem;
+}

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,6 +1,8 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { useEffect } from 'react';
 import { getMissions } from '../redux/missions/missionsSlice';
+import Mission from './Mission';
+import './Missions.css';
 
 export default function Missions() {
   const { missions } = useSelector((store) => store.missions);
@@ -11,8 +13,26 @@ export default function Missions() {
       dispatch(getMissions());
     }
   }, []);
-
-  // console.log('Hello');
-  console.log(missions);
-  return <div>missions</div>;
+  return (
+    <table>
+      <thead>
+        <tr>
+          <th>Mission</th>
+          <th>Description</th>
+          <th>Status</th>
+          <th> </th>
+        </tr>
+      </thead>
+      <tbody>
+        {missions.map((mission) => (
+          <Mission
+            key={mission.mission_id}
+            name={mission.mission_name}
+            description={mission.description}
+            isMember={false}
+          />
+        ))}
+      </tbody>
+    </table>
+  );
 }

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,18 +1,18 @@
 import { useDispatch, useSelector } from 'react-redux';
-import { getMissions } from '../redux/missions/missionsSlice';
 import { useEffect } from 'react';
+import { getMissions } from '../redux/missions/missionsSlice';
 
 export default function Missions() {
-  const missions = useSelector((store) => store.missions);
+  const { missions } = useSelector((store) => store.missions);
   const dispatch = useDispatch();
 
   useEffect(() => {
-    if(missions.missionsArr.length === 0) {
+    if (missions.length === 0) {
       dispatch(getMissions());
     }
-  }, [])
+  }, []);
 
-  console.log('Hello');
+  // console.log('Hello');
   console.log(missions);
   return <div>missions</div>;
 }

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,10 +1,17 @@
 import { useDispatch, useSelector } from 'react-redux';
 import { getMissions } from '../redux/missions/missionsSlice';
+import { useEffect } from 'react';
 
 export default function Missions() {
   const missions = useSelector((store) => store.missions);
   const dispatch = useDispatch();
-  dispatch(getMissions());
+
+  useEffect(() => {
+    if(missions.missionsArr.length === 0) {
+      dispatch(getMissions());
+    }
+  }, [])
+
   console.log('Hello');
   console.log(missions);
   return <div>missions</div>;

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,3 +1,11 @@
+import { useDispatch, useSelector } from 'react-redux';
+import { getMissions } from '../redux/missions/missionsSlice';
+
 export default function Missions() {
-  return <div>Missions</div>;
+  const missions = useSelector((store) => store.missions);
+  const dispatch = useDispatch();
+  dispatch(getMissions());
+  console.log('Hello');
+  console.log(missions);
+  return <div>missions</div>;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
+import { Provider } from 'react-redux';
 import './index.css';
 import App from './App';
+import store from './redux/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
-    <App />
+    <Provider store={store}>
+      <App />
+    </Provider>
   </React.StrictMode>,
 );

--- a/src/index.js
+++ b/src/index.js
@@ -7,9 +7,7 @@ import store from './redux/store';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <Provider store={store}>
-      <App />
-    </Provider>
-  </React.StrictMode>,
+  <Provider store={store}>
+    <App />
+  </Provider>,
 );

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -1,0 +1,53 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+import axios from 'axios';
+
+const API_URL = 'https://api.spacexdata.com/v3/missions';
+
+export const getMissions = createAsyncThunk(
+  'missions/getMissions',
+  async () => {
+    try {
+      const response = await axios.get(API_URL);
+      return response.data;
+    } catch (error) {
+      return error.message;
+    }
+  },
+);
+
+const initialState = {
+  missionsArr: [],
+  status: 'idle',
+  error: null,
+};
+
+const missionsSlice = createSlice({
+  name: 'missions',
+  initialState,
+  reducers: {},
+  extraReducers: (builder) => {
+    builder.addCase(getMissions.fulfilled, (state, action) => {
+      state.status = 'fulfilled';
+      const missions = [];
+      action.payload.forEach((mission) => {
+        const newMission = {
+          id: mission.mission_id,
+          name: mission.mission_name,
+          description: mission.description,
+          activeMember: false,
+        };
+        missions.push(newMission);
+      });
+      state.missionsArr = missions;
+    });
+    builder.addCase(getMissions.pending, (state) => {
+      state.status = 'Loading';
+    });
+    builder.addCase(getMissions.rejected, (state, action) => {
+      state.status = 'rejected';
+      state.error = action.error.message;
+    });
+  },
+});
+
+export default missionsSlice.reducer;

--- a/src/redux/missions/missionsSlice.js
+++ b/src/redux/missions/missionsSlice.js
@@ -10,13 +10,13 @@ export const getMissions = createAsyncThunk(
       const response = await axios.get(API_URL);
       return response.data;
     } catch (error) {
-      return error.message;
+      throw new Error(error.message);
     }
   },
 );
 
 const initialState = {
-  missionsArr: [],
+  missions: [],
   status: 'idle',
   error: null,
 };
@@ -26,22 +26,12 @@ const missionsSlice = createSlice({
   initialState,
   reducers: {},
   extraReducers: (builder) => {
+    builder.addCase(getMissions.pending, (state) => {
+      state.status = 'pending';
+    });
     builder.addCase(getMissions.fulfilled, (state, action) => {
       state.status = 'fulfilled';
-      const missions = [];
-      action.payload.forEach((mission) => {
-        const newMission = {
-          id: mission.mission_id,
-          name: mission.mission_name,
-          description: mission.description,
-          activeMember: false,
-        };
-        missions.push(newMission);
-      });
-      state.missionsArr = missions;
-    });
-    builder.addCase(getMissions.pending, (state) => {
-      state.status = 'Loading';
+      state.missions = action.payload;
     });
     builder.addCase(getMissions.rejected, (state, action) => {
       state.status = 'rejected';

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -1,0 +1,12 @@
+import { configureStore } from '@reduxjs/toolkit';
+import missionsReducer from './missions/missionsSlice';
+import rocketsReducer from './rockets/rocketsSlice';
+
+const store = configureStore({
+  reducer: {
+    missions: missionsReducer,
+    rockets: rocketsReducer,
+  },
+});
+
+export default store;

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -2,7 +2,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import missionsReducer from './missions/missionsSlice';
 import rocketsReducer from './rockets/rocketsSlice';
 
-import fetchRockets from './Rocket/RocketSlice';
+// import fetchRockets from './Rocket/RocketSlice';
 
 const store = configureStore({
   reducer: {
@@ -12,6 +12,6 @@ const store = configureStore({
 });
 
 // Fetch rockets when the application starts
-store.dispatch(fetchRockets);
+// store.dispatch(fetchRockets);
 
 export default store;

--- a/src/routes/Missions.js
+++ b/src/routes/Missions.js
@@ -1,5 +1,5 @@
 import Missions from '../components/Missions';
 
 export default function MissionsList() {
-  <Missions />;
+  return <Missions />;
 }

--- a/src/routes/Rockets.js
+++ b/src/routes/Rockets.js
@@ -1,5 +1,5 @@
 import Rockets from '../components/Rockets';
 
 export default function RocketsList() {
-  <Rockets />;
+  return <Rockets />;
 }


### PR DESCRIPTION
Hello @theresetuyi in this branch I did the following:
Fetch:
- [x] Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- [x] Once the data are fetched, dispatch an action to store the selected data in Redux store:
- mission_id
- mission_name
- description
- [x] Only dispatch those actions once and do not add data to store on every re-render (i.e. when changing views / using navigation).

 Render:
- [x] Use useSelector() Redux Hook to select the state slices and render lists of missions in corresponding routes. i.e.: // get rockets data from the store: const rockets = useSelector(state => state.rockets);
- [x] I style the whole application "by hand"
- [x] Render a table with the missions' data (as per design).